### PR TITLE
MIQ dialog doesn't supports array as value

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -17,5 +17,5 @@
     shell: >
       primary_ip=$(ovn-nbctl lr-nat-list {{ ovn_lb_router }} | grep ^snat | awk '{print $2}');
       [ -z "$primary_ip" ] && exit 1;
-      ovn-nbctl --may-exist lb-add {{ ovn_lb_name }} $primary_ip:{{ lb_port }} {{ lb_backends | join(',') }} {{ lb_proto | d('tcp') }} &&
+      ovn-nbctl --may-exist lb-add {{ ovn_lb_name }} $primary_ip:{{ lb_port }} {{ lb_backends }} {{ lb_proto | d('tcp') }} &&
       ovn-nbctl --may-exist lr-lb-add {{ ovn_lb_router }} {{ ovn_lb_name }}


### PR DESCRIPTION
We passing params via manageiq automation dialog. MIQ dialog doesn't supports array as values